### PR TITLE
[HomePage] Issue #6 홈페이지의 Talent List영역에 대한 초기 구현입니다.

### DIFF
--- a/src/components/Home/TalentBest.vue
+++ b/src/components/Home/TalentBest.vue
@@ -1,0 +1,12 @@
+<template>
+  <div data-test="talent-best">
+    <h1>탈잉 BEST입니다.</h1>
+  </div>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style>
+</style>

--- a/src/components/Home/TalentRecommended.vue
+++ b/src/components/Home/TalentRecommended.vue
@@ -1,0 +1,12 @@
+<template>
+  <div data-test="talent-recommended">
+    <h1>추천수업입니다.</h1>
+  </div>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style>
+</style>

--- a/src/components/Home/TalentsList.vue
+++ b/src/components/Home/TalentsList.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="border-2 my-4 px-4 py-2" data-test="tab-area">
+    <ul class="flex justify-around border-2 my-2">
+      <li
+        v-for="tab in talentsList"
+        :key="tab"
+        data-test="talent-list-tab-category"
+      >
+        <button
+          class="my-2 px-4 py-4"
+          @click="initialTab = tab.component"
+          :data-test="`${tab.nameKr}`"
+        >
+          {{ tab.nameKr }}
+        </button>
+      </li>
+    </ul>
+    <component :is="initialTab" class="border-2 px-2 py-2"></component>
+  </div>
+</template>
+
+<script>
+import TalentBest from '@/components/Home/TalentBest.vue';
+import TalentRecommended from '@/components/Home/TalentRecommended.vue';
+
+export default {
+  components: {
+    TalentBest,
+    TalentRecommended,
+  },
+  data() {
+    return {
+      initialTab: 'TalentRecommended',
+      talentsList: [
+        { component: 'TalentRecommended', nameKr: '추천수업' },
+        { component: 'TalentBest', nameKr: '탈잉 BEST' },
+      ],
+    };
+  },
+};
+</script>
+
+<style>
+</style>

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -99,8 +99,9 @@
   <main>
     <div class="max-w-6xl mx-auto px-4">
       <div class="flex">
-        <div class="flex w-2/3 left-column">
+        <div class="flex flex-col w-2/3 left-column">
           <RollingBanner></RollingBanner>
+          <TalentsList></TalentsList>
         </div>
       </div>
     </div>
@@ -110,11 +111,13 @@
 
 <script>
 import RollingBanner from '@/components/Home/RollingBanner.vue';
+import TalentsList from '@/components/Home/TalentsList.vue';
 
 export default {
   name: 'HomePage',
   components: {
     RollingBanner,
+    TalentsList,
   },
   data() {
     return {

--- a/tests/unit/components/Home/TalentBest.spec.js
+++ b/tests/unit/components/Home/TalentBest.spec.js
@@ -1,0 +1,10 @@
+import { mount } from '@vue/test-utils';
+import TalentBest from '@/components/Home/TalentBest.vue';
+
+describe('탈잉 BEST 탭 영역에 대한 element존재 여부를 검증합니다.', () => {
+  const wrapper = mount(TalentBest);
+
+  test('탈잉 베스트 영역이 존재하는지 확인합니다.', () => {
+    expect(wrapper.find('div[data-test="talent-best"]').exists()).toBeTruthy();
+  });
+});

--- a/tests/unit/components/Home/TalentRecommended.spec.js
+++ b/tests/unit/components/Home/TalentRecommended.spec.js
@@ -1,0 +1,10 @@
+import { mount } from '@vue/test-utils';
+import TalentRecommended from '@/components/Home/TalentRecommended.vue';
+
+describe('추천수업 탭 영역에 대한 element존재 여부를 검증합니다.', () => {
+  const wrapper = mount(TalentRecommended);
+
+  test('추천수업 영역이 존재하는지 확인합니다.', () => {
+    expect(wrapper.find('div[data-test="talent-recommended"]').exists()).toBeTruthy();
+  });
+});

--- a/tests/unit/components/Home/TalentsList.spec.js
+++ b/tests/unit/components/Home/TalentsList.spec.js
@@ -1,0 +1,23 @@
+import { mount } from '@vue/test-utils';
+import TalentsList from '@/components/Home/TalentsList.vue';
+
+describe('클래스 목록을 표시해주는 영역에 대한 테스트 입니다.', () => {
+  const wrapper = mount(TalentsList);
+
+  it('클래스 목록을 표시해주는 영역이 존재합니다.', () => {
+    expect(wrapper.find('div[data-test="tab-area"]').exists()).toBeTruthy();
+  });
+
+  it('N개의 클래스 카테고리 선택 탭이 존재합니다.', async () => {
+    const testTalentsList = [
+      { nameKr: '이번주 시작' },
+      { nameKr: '원데이 BEST' },
+      { nameKr: '다회차 BEST' },
+    ];
+    await wrapper.setData({
+      talentsList: testTalentsList,
+    });
+
+    expect(wrapper.findAll('li[data-test="talent-list-tab-category"]').length).toBe(testTalentsList.length);
+  });
+});


### PR DESCRIPTION
#### 홈페이지의 Left Column의 Talent List에 대한 구현입니다.

 - 각각의 탭을 하나의 컴포넌트로 고려하고 설계를 진행하였습니다.
 - MVP에서는 추천 수업과, 탈잉 BEST의 두가지 탭으로 설계를 진행하여 아래와 같은 컴포넌트를 생성하였습니다.
   - TalentRecommended.vue
   - TalentBest.vue
 - 위 두가지 컴포넌트는 TalentList.vue의 하위 컴포넌트 입니다.
 
[FE] 테스트 시나리오
- [x]  Element 존재여부 - (TalentsList.spec.js)
    - [x]  클래스 목록을 표시해주는 영역이 존재합니다. - tab-area
    - [x]  N개의 클래스 카테고리 선택 탭이 존재합니다. - talent-list-tab-category

#### 구현에 대한 결과물입니다.

![tab-components](https://user-images.githubusercontent.com/16056892/159488313-cb6ff9a7-ef48-4f70-b17f-339c326326c9.gif)


####특이사항
- TalentList의 하위컴포넌트는 초기 TC만 작성했습니다.
- Component에 대한 구조 refactoring이 필요해보입니다.
   - TalentList 파일은 views 폴더에 더 적합하다는 생각이 듭니다. 조금더 고민해보고 적용하고자 합니다.


