### PR TITLE
[Homepage] refactor: improve carousel reusability 

### DIFF
--- a/src/components/Home/MultiCarouselControl.vue
+++ b/src/components/Home/MultiCarouselControl.vue
@@ -22,15 +22,14 @@
     </div>
   </div>
   <div class="overflow-hidden relative w-full pt-80">
-    <div class="overflow-hidden absolute inset-0 flex flex-nowrap">
-      <div
-        class="w-full flex flex-wrap ease-out duration-300"
+    <div class="absolute inset-0">
+      <ul
+        class="flex flex-nowrap ease-out duration-300"
         :ref="`carousel-content-${title}`"
+        data-test="carousel-contents"
       >
-        <ul class="flex flex-nowrap" data-test="carousel-contents">
-          <slot></slot>
-        </ul>
-      </div>
+        <slot></slot>
+      </ul>
     </div>
   </div>
 </template>
@@ -46,15 +45,16 @@ export default {
   props: {
     title: { type: String, default: '' },
     totalSlide: { type: Number, default: -1 },
+    slidesToShow: { type: Number, default: -1 },
   },
   methods: {
     slideAction() {
       const carouselContent = this.$refs[`carousel-content-${this.title}`];
       if (carouselContent) {
         const size = carouselContent.clientWidth;
-        carouselContent.style.transform = `translateX(-${
-          (this.slideIndex * size) / 3
-        }px)`;
+        carouselContent.style.transform = `translateX(-${Math.floor(
+          (this.slideIndex * size) / this.slidesToShow,
+        )}px)`;
       }
     },
     prevSlide() {

--- a/src/components/Home/MultiCarouselItem.vue
+++ b/src/components/Home/MultiCarouselItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <li class="w-1/3 min-w-[25%] px-2 py-2 relative" :data-test="id">
+  <li :class="`min-w-[${slideWidth}%]`" class="px-2 relative" :data-test="id">
     <img
       :src="image"
       class="w-full h-32 rounded-lg"
@@ -91,6 +91,7 @@ export default {
     return {
       wishImage:
         'https://front-img.taling.me/Content/app3/img/icon/icWishUnclickedLine38Px@2x.png',
+      slideWidth: 25,
     };
   },
   props: {

--- a/src/components/Home/MultiCarouselItem.vue
+++ b/src/components/Home/MultiCarouselItem.vue
@@ -91,10 +91,10 @@ export default {
     return {
       wishImage:
         'https://front-img.taling.me/Content/app3/img/icon/icWishUnclickedLine38Px@2x.png',
-      slideWidth: 25,
     };
   },
   props: {
+    slideWidth: { type: Number, default: -1 },
     id: { type: String, default: '' },
     image: { type: String, default: '' },
     badge_list: {

--- a/src/components/Home/MultiCarouselItem.vue
+++ b/src/components/Home/MultiCarouselItem.vue
@@ -1,5 +1,9 @@
 <template>
-  <li :class="`min-w-[${slideWidth}%]`" class="px-2 relative" :data-test="id">
+  <li
+    :class="`min-w-[${slideWidth}%]`"
+    class="w-1/3 px-2 relative"
+    :data-test="id"
+  >
     <img
       :src="image"
       class="w-full h-32 rounded-lg"

--- a/src/views/Home/TalentBest.vue
+++ b/src/views/Home/TalentBest.vue
@@ -2,22 +2,22 @@
   <div data-test="talent-best">
     <h1 class="font-bold pl-2">탈잉 BEST</h1>
     <ul class="flex flex-wrap">
-      <TalentItem
+      <MultiCarouselItem
         v-for="talent in talentsApi"
         :key="talent.id"
         v-bind="talent"
-      ></TalentItem>
+      ></MultiCarouselItem>
     </ul>
   </div>
 </template>
 
 <script>
-import TalentItem from '@/components/Home/TalentItem.vue';
+import MultiCarouselItem from '@/components/Home/MultiCarouselItem.vue';
 import TalentItemApi from '@/api/Home/TalentList';
 
 export default {
   components: {
-    TalentItem,
+    MultiCarouselItem,
   },
   data() {
     return {

--- a/src/views/Home/TalentRecommended.vue
+++ b/src/views/Home/TalentRecommended.vue
@@ -1,34 +1,38 @@
 <template>
   <div data-test="talent-recommended">
-    <MultiCarousel
+    <MultiCarouselControl
       v-for="talent in talents"
       :key="talent.id"
       :title="talent.title"
       :totalSlide="talent.contents.length"
+      :slidesToShow="slidesToShow"
     >
-      <TalentItem
+      <MultiCarouselItem
         v-for="talent in talent.contents"
         :key="talent.id"
+        :slideWidth="slideWidth"
         v-bind="talent"
       >
-      </TalentItem>
-    </MultiCarousel>
+      </MultiCarouselItem>
+    </MultiCarouselControl>
   </div>
 </template>
 
 <script>
-import TalentItem from '@/components/Home/TalentItem.vue';
-import MultiCarousel from '@/components/Home/MultiCarousel.vue';
+import MultiCarouselItem from '@/components/Home/MultiCarouselItem.vue';
+import MultiCarouselControl from '@/components/Home/MultiCarouselControl.vue';
 import talentsModel from '@/model/Home/TalentRecommended';
 
 export default {
   components: {
-    TalentItem,
-    MultiCarousel,
+    MultiCarouselItem,
+    MultiCarouselControl,
   },
   data() {
     return {
       talents: talentsModel,
+      slidesToShow: 4,
+      slideWidth: this.slidesToShow / 100,
     };
   },
 };

--- a/src/views/Home/TalentRecommended.vue
+++ b/src/views/Home/TalentRecommended.vue
@@ -31,8 +31,8 @@ export default {
   data() {
     return {
       talents: talentsModel,
-      slidesToShow: 4,
-      slideWidth: this.slidesToShow / 100,
+      slidesToShow: 3,
+      slideWidth: 33,
     };
   },
 };

--- a/tests/unit/components/Home/MultiCarouselControl.spec.js
+++ b/tests/unit/components/Home/MultiCarouselControl.spec.js
@@ -1,8 +1,8 @@
 import { mount } from '@vue/test-utils';
-import MultiCarousel from '@/components/Home/MultiCarousel.vue';
+import MultiCarouselControl from '@/components/Home/MultiCarouselControl.vue';
 
 describe('Carousel 컴포넌트의 element존재 여부를 검증합니다.', () => {
-  const wrapper = mount(MultiCarousel);
+  const wrapper = mount(MultiCarouselControl);
 
   test('carousel별로 타이틀이 존재하는지 확인합니다.', () => {
     expect(wrapper.find('[data-test="carousel-title"]').exists()).toBeTruthy();

--- a/tests/unit/components/Home/MultiCarouselItem.spec.js
+++ b/tests/unit/components/Home/MultiCarouselItem.spec.js
@@ -1,8 +1,8 @@
 import { mount } from '@vue/test-utils';
-import TalentItem from '@/components/Home/TalentItem.vue';
+import MultiCarouselItem from '@/components/Home/MultiCarouselItem.vue';
 
 describe('클래스 목록 아이템 컴포넌트의 element 존재여부에 대한 검증입니다.', () => {
-  const wrapper = mount(TalentItem);
+  const wrapper = mount(MultiCarouselItem);
 
   test('썸네일 이미지가 존재해야합니다. ', () => {
     expect(wrapper.find('img[data-test="talent-thumb-image"]').exists()).toBeTruthy();
@@ -65,7 +65,7 @@ describe('TalentList.vue페이지에서 사용될 TalentItem.vue컴포넌트의 
     talent_title: 'How to build coherent unit test cases and E2E test cases',
   };
 
-  const wrapper = mount(TalentItem, {
+  const wrapper = mount(MultiCarouselItem, {
     props: testProps,
   });
 


### PR DESCRIPTION
## Carousel 재사용성을 증대시키기 위해 아래와 같은 작업을 진행했습니다.
- 컴포넌트 name 변경
  - 조금더 명시적인 파일명으로 변경하였습니다.
- props 설정
  - MultiCarouselControl 컴포넌트에는 slidesToShow라는 props로 carousel 안에 보여줄 아이템의 갯수를 설정합니다.
  - MultiCarouselItem 컴포너느에는 slideWidth라는 props로 carousel Item의 너비를 설정합니다.
  - 위와 같은 props로 조금더 재사용성 coverage 가 높아질것으로 생각됩니다.

## 미해결 Issue 
 - Carousel을 구현하던중 홀수 개의 slide를 표현하는 시도중 px계산이 불분명하여 아래와같은 현상이 발생
<img width="445" alt="Screen Shot 2022-04-01 at 11 11 18 am" src="https://user-images.githubusercontent.com/16056892/161180854-7eb466b2-2be4-49d3-a408-cf5440c66a8f.png">

 - next slide item의 내용이 삐져나오는 현상
 - Issue로 등록하여 추후 해결하도록 하겠습니다.
 