### PR TITLE
[Hompage] #32 create category section

### DIFF
--- a/src/components/Home/CategoryItem.vue
+++ b/src/components/Home/CategoryItem.vue
@@ -1,7 +1,11 @@
 <template>
-  <li :class="`w-[${itemWidth}%]`" class="text-center font-bold">
-    <a :href="`${link_url}`"
-      ><span
+  <li
+    :class="`w-[${itemWidth}%]`"
+    class="text-center font-bold"
+    data-test="category-item"
+  >
+    <a :href="`${link_url}`" data-test="category-link">
+      <span
         class="
           block
           w-[68px]
@@ -11,9 +15,10 @@
           bg-contain bg-slate-50
           rounded-lg
         "
-        :style="{ backgroundImage: `url(${image_url})` }"
-      ></span
-      >{{ text }}
+        :style="getBackgroundImage"
+        data-test="category-image"
+      ></span>
+      {{ text }}
     </a>
   </li>
 </template>
@@ -26,6 +31,13 @@ export default {
     image_url: { type: String, default: '' },
     text: { type: String, default: '' },
     category_id: { type: String, default: '' },
+  },
+
+  computed: {
+    getBackgroundImage() {
+      const result = `background-image: url(${this.image_url})`;
+      return result;
+    },
   },
 };
 </script>

--- a/src/components/Home/CategoryItem.vue
+++ b/src/components/Home/CategoryItem.vue
@@ -1,0 +1,34 @@
+<template>
+  <li :class="`w-[${itemWidth}%]`" class="text-center font-bold">
+    <a :href="`${link_url}`"
+      ><span
+        class="
+          block
+          w-[68px]
+          h-[68px]
+          m-auto
+          mb-4
+          bg-contain bg-slate-50
+          rounded-lg
+        "
+        :style="{ backgroundImage: `url(${image_url})` }"
+      ></span
+      >{{ text }}
+    </a>
+  </li>
+</template>
+
+<script>
+export default {
+  props: {
+    itemWidth: { type: Number, default: -1 },
+    link_url: { type: String, default: '' },
+    image_url: { type: String, default: '' },
+    text: { type: String, default: '' },
+    category_id: { type: String, default: '' },
+  },
+};
+</script>
+
+<style>
+</style>

--- a/src/model/Home/CategoryWrapper.js
+++ b/src/model/Home/CategoryWrapper.js
@@ -1,0 +1,62 @@
+export default [
+  {
+    link_url: 'https://taling.me/vod/list',
+    image_url: 'https://img.taling.me/Content/Uploads/Images/2e87ed801461b9ad64f8c2609ce1cd137ca0fed6.png',
+    text: '오리지널',
+    category_id: 'unique_id_0',
+  },
+  {
+    link_url: 'https://taling.me/Home/Search/?classTypeCode=1',
+    image_url: 'https://img.taling.me/Content/Uploads/Images/f85a4acfa613e8fa9f65c16a2c2a1624ef619454.png',
+    text: '오프라인',
+    category_id: 'unique_id_1',
+  },
+  {
+    link_url: 'https://taling.me/Home/Search/?classTypeCode=2',
+    image_url: 'https://img.taling.me/Content/Uploads/Images/3a848a2fb3bd1946de7b852fefa47c5d28b63602.png',
+    text: '온라인LIVE',
+    category_id: 'unique_id_2',
+  },
+  {
+    link_url: 'https://taling.me/Home/Search/?classTypeCode=4',
+    image_url: 'https://img.taling.me/Content/Uploads/Images/18f7f847be7590d75d81b38d2628f411c06479d4.png',
+    text: '전자책',
+    category_id: 'unique_id_3',
+  },
+  {
+    link_url: 'https://taling.me/Home/Search/?classTypeCode=3',
+    image_url: 'https://img.taling.me/Content/Uploads/Images/ff560fe416dc7214a1454047e3ca9797fa826601.png',
+    text: 'VOD',
+    category_id: 'unique_id_4',
+  },
+  {
+    link_url: 'https://taling.me/Promotion/promotionList.php?id=473&query=%ED%99%88%EC%88%8F%EC%BB%B7_%EC%A3%BC%EA%B0%84%EB%B2%A0%EC%8A%A4%ED%8A%B8',
+    image_url: 'https://img.taling.me/Content/Uploads/Images/1fc454856cd3c90bb8d4074aad5189620681866a.png',
+    text: '주간 베스트',
+    category_id: 'unique_id_5',
+  },
+  {
+    link_url: 'https://taling.me/Promotion/promotionList.php?id=477&query=%ED%99%88%EC%88%8F%EC%BB%B7_%ED%95%A0%EC%9D%B8%ED%98%9C%ED%83%9D',
+    image_url: 'https://img.taling.me/Content/Uploads/Images/e26f87487859bb1927bc35a419a291e83b20c391.png',
+    text: '할인 혜택',
+    category_id: 'unique_id_6',
+  },
+  {
+    link_url: 'https://taling.me/Promotion/promotionList.php?id=474&query=%ED%99%88%EC%88%8F%EC%BB%B7_%EC%8B%A0%EA%B7%9C%EC%98%A4%ED%94%88',
+    image_url: 'https://img.taling.me/Content/Uploads/Images/031f9501e9ffebf1bb2e29fc10c9ce0f30ffacce.png',
+    text: '신규 오픈',
+    category_id: 'unique_id_7',
+  },
+  {
+    link_url: 'https://taling.me/Promotion/promotionList.php?id=478&query=%EC%8A%A4%ED%83%80%ED%85%81%EC%8B%9C%EB%A6%AC%EC%A6%88',
+    image_url: 'https://img.taling.me/Content/Uploads/Images/378e309407eae8e1f195cb8437055ccbcd64e1d2.png',
+    text: '스타텁 시리즈',
+    category_id: 'unique_id_8',
+  },
+  {
+    link_url: 'https://taling.me/Promotion/promotionList.php?id=475&query=%ED%99%88%EC%88%8F%EC%BB%B7_%ED%83%88%EC%9E%89%ED%94%BD',
+    image_url: 'https://img.taling.me/Content/Uploads/Images/bb3f761974a89b30c52a3388dc40c026226f4f81.png',
+    text: '탈잉 픽',
+    category_id: 'unique_id_9',
+  },
+];

--- a/src/views/Home/CategoryWrapper.vue
+++ b/src/views/Home/CategoryWrapper.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="mb-16">
+    <ul class="flex" data-test="category">
+      <CategoryItem
+        v-for="category in list_category"
+        :key="category.category_id"
+        :itemWidth="itemWidth"
+        v-bind="category"
+      />
+    </ul>
+  </div>
+</template>
+
+<script>
+import CategoryItem from '@/components/Home/CategoryItem.vue';
+import CategoryModel from '@/model/Home/CategoryWrapper';
+
+export default {
+  components: {
+    CategoryItem,
+  },
+  data() {
+    return {
+      itemWidth: 10,
+      list_category: CategoryModel,
+    };
+  },
+};
+</script>
+
+<style>
+</style>

--- a/src/views/Home/CategoryWrapper.vue
+++ b/src/views/Home/CategoryWrapper.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mb-16">
-    <ul class="flex" data-test="category">
+    <ul class="flex" data-test="category-wrapper">
       <CategoryItem
         v-for="category in list_category"
         :key="category.category_id"

--- a/src/views/Home/HomePage.vue
+++ b/src/views/Home/HomePage.vue
@@ -99,9 +99,14 @@
   </header>
   <main>
     <div class="max-w-6xl mx-auto px-4">
+      <div class="mb-16" data-test="visual">
+        <RollingBanner></RollingBanner>
+      </div>
+      <CategoryWrapper></CategoryWrapper>
+    </div>
+    <div class="max-w-6xl mx-auto px-4">
       <div class="flex">
         <div class="flex flex-col w-2/3 left-column">
-          <RollingBanner></RollingBanner>
           <TalentsList></TalentsList>
         </div>
       </div>
@@ -115,6 +120,7 @@
 <script>
 import RollingBanner from '@/views/Home/RollingBanner.vue';
 import TalentsList from '@/views/Home/TalentsWrapper.vue';
+import CategoryWrapper from '@/views/Home/CategoryWrapper.vue';
 import Footer from '@/components/FooterCom.vue';
 
 export default {
@@ -122,6 +128,7 @@ export default {
   components: {
     RollingBanner,
     TalentsList,
+    CategoryWrapper,
     Footer,
   },
   data() {

--- a/tests/unit/components/Home/CategoryItem.spec.js
+++ b/tests/unit/components/Home/CategoryItem.spec.js
@@ -1,0 +1,48 @@
+import { mount } from '@vue/test-utils';
+import CategoryItem from '@/components/Home/CategoryItem.vue';
+
+describe('CategoryItem.vue 파일중 존재해야할 element에 대한 검증 입니다.', () => {
+	const wrapper = mount(CategoryItem);
+
+	test('카테고리 아이템이 list 형태로 존재 해야합니다.', () => {
+		expect(wrapper.find('li[data-test="category-item"]').exists()).toBeTruthy();
+	})
+
+	test('카테고리 아이템의 링크가 존재 해야합니다.', () => {
+		expect(wrapper.find('[data-test="category-link"]').exists()).toBeTruthy();
+	})
+
+	test('카테고리 이미지가 존재 해야합니다.', () => {
+		expect(wrapper.find('[data-test="category-image"]').exists()).toBeTruthy();
+	})
+})
+
+describe('CategoryItem.vue 파일의 data binding의 여부에 대한 검증 입니다.', () => {
+	const testProps = {
+		itemWidth: 15,
+		link_url: 'test-link-url',
+		image_url: 'test-image-url',
+		text: '테스트 카테고리 이름',
+	};
+	const wrapper = mount(CategoryItem, {
+		props: testProps,
+	});
+
+	test('카테고리 아이템의 너비가 의도한 data와 일치하는지 확인합니다.', () => {
+		const testItemWidth = `w-[${testProps.itemWidth}%]`;
+		expect(wrapper.get('li[data-test="category-item"]').classes()).toContain(testItemWidth)
+	})
+
+	test('카테고리 아이템의 링크가 의도한 data와 일치하는지 확인합니다.', () => {
+		expect(wrapper.get('[data-test="category-link"]').attributes('href')).toStrictEqual(testProps.link_url)
+	})
+
+	test('카테고리 아이템의 이미지가 의도한 data와 일치하는지 확인합니다.', () => {
+		const testCategoryImage = `background-image: url(${testProps.image_url});`
+		expect(wrapper.get('[data-test="category-image"]').attributes('style')).toBe(testCategoryImage)
+	})
+
+	test('카테고리 아이템의 텍스트가 의도한 data와 일치하는지 확인합니다.', () => {
+		expect(wrapper.get('[data-test="category-link"]').text()).toBe(testProps.text);
+	})
+})

--- a/tests/unit/components/Home/CategoryItem.spec.js
+++ b/tests/unit/components/Home/CategoryItem.spec.js
@@ -2,47 +2,47 @@ import { mount } from '@vue/test-utils';
 import CategoryItem from '@/components/Home/CategoryItem.vue';
 
 describe('CategoryItem.vue 파일중 존재해야할 element에 대한 검증 입니다.', () => {
-	const wrapper = mount(CategoryItem);
+  const wrapper = mount(CategoryItem);
 
-	test('카테고리 아이템이 list 형태로 존재 해야합니다.', () => {
-		expect(wrapper.find('li[data-test="category-item"]').exists()).toBeTruthy();
-	})
+  test('카테고리 아이템이 list 형태로 존재 해야합니다.', () => {
+    expect(wrapper.find('li[data-test="category-item"]').exists()).toBeTruthy();
+  });
 
-	test('카테고리 아이템의 링크가 존재 해야합니다.', () => {
-		expect(wrapper.find('[data-test="category-link"]').exists()).toBeTruthy();
-	})
+  test('카테고리 아이템의 링크가 존재 해야합니다.', () => {
+    expect(wrapper.find('[data-test="category-link"]').exists()).toBeTruthy();
+  });
 
-	test('카테고리 이미지가 존재 해야합니다.', () => {
-		expect(wrapper.find('[data-test="category-image"]').exists()).toBeTruthy();
-	})
-})
+  test('카테고리 이미지가 존재 해야합니다.', () => {
+    expect(wrapper.find('[data-test="category-image"]').exists()).toBeTruthy();
+  });
+});
 
 describe('CategoryItem.vue 파일의 data binding의 여부에 대한 검증 입니다.', () => {
-	const testProps = {
-		itemWidth: 15,
-		link_url: 'test-link-url',
-		image_url: 'test-image-url',
-		text: '테스트 카테고리 이름',
-	};
-	const wrapper = mount(CategoryItem, {
-		props: testProps,
-	});
+  const testProps = {
+    itemWidth: 15,
+    link_url: 'test-link-url',
+    image_url: 'test-image-url',
+    text: '테스트 카테고리 이름',
+  };
+  const wrapper = mount(CategoryItem, {
+    props: testProps,
+  });
 
-	test('카테고리 아이템의 너비가 의도한 data와 일치하는지 확인합니다.', () => {
-		const testItemWidth = `w-[${testProps.itemWidth}%]`;
-		expect(wrapper.get('li[data-test="category-item"]').classes()).toContain(testItemWidth)
-	})
+  test('카테고리 아이템의 너비가 의도한 data와 일치하는지 확인합니다.', () => {
+    const testItemWidth = `w-[${testProps.itemWidth}%]`;
+    expect(wrapper.get('li[data-test="category-item"]').classes()).toContain(testItemWidth);
+  });
 
-	test('카테고리 아이템의 링크가 의도한 data와 일치하는지 확인합니다.', () => {
-		expect(wrapper.get('[data-test="category-link"]').attributes('href')).toStrictEqual(testProps.link_url)
-	})
+  test('카테고리 아이템의 링크가 의도한 data와 일치하는지 확인합니다.', () => {
+    expect(wrapper.get('[data-test="category-link"]').attributes('href')).toStrictEqual(testProps.link_url);
+  });
 
-	test('카테고리 아이템의 이미지가 의도한 data와 일치하는지 확인합니다.', () => {
-		const testCategoryImage = `background-image: url(${testProps.image_url});`
-		expect(wrapper.get('[data-test="category-image"]').attributes('style')).toBe(testCategoryImage)
-	})
+  test('카테고리 아이템의 이미지가 의도한 data와 일치하는지 확인합니다.', () => {
+    const testCategoryImage = `background-image: url(${testProps.image_url});`;
+    expect(wrapper.get('[data-test="category-image"]').attributes('style')).toBe(testCategoryImage);
+  });
 
-	test('카테고리 아이템의 텍스트가 의도한 data와 일치하는지 확인합니다.', () => {
-		expect(wrapper.get('[data-test="category-link"]').text()).toBe(testProps.text);
-	})
-})
+  test('카테고리 아이템의 텍스트가 의도한 data와 일치하는지 확인합니다.', () => {
+    expect(wrapper.get('[data-test="category-link"]').text()).toBe(testProps.text);
+  });
+});

--- a/tests/unit/views/Home/CategoryWrapper.spec.js
+++ b/tests/unit/views/Home/CategoryWrapper.spec.js
@@ -1,0 +1,22 @@
+import { mount } from '@vue/test-utils';
+import CategoryWrapper from '@/views/Home/CategoryWrapper.vue';
+import CategoryItem from '@/components/Home/CategoryItem.vue';
+
+describe('CategoryWrapper.vue 파일중 존재해야할 element에 대한 검증입니다.', () => {
+	const wrapper = mount(CategoryWrapper);
+
+
+	test('CategoryWrapper 영역이 존재해야합니다.', () => {
+		expect(wrapper.find('[data-test="category-wrapper"]').exists()).toBeTruthy();
+	})
+
+	test('CategoryItem 컴포넌트의 갯수가 의도한 data만큼 렌더링 되어야합니다.', async () => {
+		const test_list_category = [{}, {}, {}, {}]
+		await wrapper.setData({
+			list_category: test_list_category
+		})
+
+		expect(wrapper.findComponent(CategoryItem).exists()).toBeTruthy()
+		expect(wrapper.findAllComponents(CategoryItem).length).toBe(test_list_category.length)
+	})
+})

--- a/tests/unit/views/Home/CategoryWrapper.spec.js
+++ b/tests/unit/views/Home/CategoryWrapper.spec.js
@@ -3,20 +3,19 @@ import CategoryWrapper from '@/views/Home/CategoryWrapper.vue';
 import CategoryItem from '@/components/Home/CategoryItem.vue';
 
 describe('CategoryWrapper.vue 파일중 존재해야할 element에 대한 검증입니다.', () => {
-	const wrapper = mount(CategoryWrapper);
+  const wrapper = mount(CategoryWrapper);
 
+  test('CategoryWrapper 영역이 존재해야합니다.', () => {
+    expect(wrapper.find('[data-test="category-wrapper"]').exists()).toBeTruthy();
+  });
 
-	test('CategoryWrapper 영역이 존재해야합니다.', () => {
-		expect(wrapper.find('[data-test="category-wrapper"]').exists()).toBeTruthy();
-	})
+  test('CategoryItem 컴포넌트의 갯수가 의도한 data만큼 렌더링 되어야합니다.', async () => {
+    const testListCategory = [{}, {}, {}, {}];
+    await wrapper.setData({
+      list_category: testListCategory,
+    });
 
-	test('CategoryItem 컴포넌트의 갯수가 의도한 data만큼 렌더링 되어야합니다.', async () => {
-		const test_list_category = [{}, {}, {}, {}]
-		await wrapper.setData({
-			list_category: test_list_category
-		})
-
-		expect(wrapper.findComponent(CategoryItem).exists()).toBeTruthy()
-		expect(wrapper.findAllComponents(CategoryItem).length).toBe(test_list_category.length)
-	})
-})
+    expect(wrapper.findComponent(CategoryItem).exists()).toBeTruthy();
+    expect(wrapper.findAllComponents(CategoryItem).length).toBe(testListCategory.length);
+  });
+});


### PR DESCRIPTION
## 목적
- 카테고리 영역을 구현합니다.

## 작업 주요내용
- N 개의 category item을 가지는 category wrapper를 생성할수 있게끔 고려하였습니다.
- category item의 width값을 props로 설정함으로 갯수가 변동이 있어도 재사용 가능하게 구현하였습니다.

## 특이사항 
- 카테고리의 이미지는 반복적이고, rendering performance를 고려하여 background-image를 활용하여 inline styling화 하였습니다.
- 하지만 image_url을 데이터로 받아와서 template literal 을 사용하였는데, 의도치 않게 double quotation 과 semicolone이 값에 포함되어 있었습니다. (해당 부분은 TC를 작성하며 발견하였고, 실제로 탈잉 홈페이를 inspector 로 분석한 바 아래와 같은 차이점이 있었습니다.)
- 차이점
```js
<!--탈잉-->
<span style="background-image: url(https://img.taling.me/Content/Uploads/Images/18f7f847be7590d75d81b38d2628f411c06479d4.png)">
</span>
<!--구현 페이지-->
<span style="background-image: url("https://img.taling.me/Content/Uploads/Images/bb3f761974a89b30c52a3388dc40c026226f4f81.png");">
</span>
```
- 렌더링상에 문제는 없으나, double quotation 과 semi colon가 생기는 문제를 추후에 해결해야할것으로 보입니다.
- 위와 같은 이유로 TC 상에서도 불필요하게 semicolon을 expected 값에 포함시켜 검증을 진행했는데 올바른 접근은 아닌것으로 생각됩니다.

##참고자료
- [img vs background-image는 언제 어떻게 사용하나요?](https://chlolisher.tistory.com/77)
- [mdn background-image](https://developer.mozilla.org/en-US/docs/Web/CSS/background-image) : background-color 설정의 이유
- [Implementing image sprites in CSS
](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Images/Implementing_image_sprites_in_CSS)
- [The Image Embed element
](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)